### PR TITLE
feat(pins): add CRUD, search, voting, and reporting for pins

### DIFF
--- a/backend/src/controllers/pins.controller.ts
+++ b/backend/src/controllers/pins.controller.ts
@@ -1,0 +1,158 @@
+import { NextFunction, Request, Response } from 'express';
+import mongoose from 'mongoose';
+import { pinModel } from '../models/pin.model';
+import { pinVoteModel } from '../models/pinVote.model';
+import {
+  CreatePinRequest,
+  UpdatePinRequest,
+  RatePinRequest,
+  ReportPinRequest,
+  SearchPinsRequest,
+  PinResponse,
+  PinsListResponse,
+} from '../types/pins.types';
+import logger from '../utils/logger.util';
+
+export class PinsController {
+  async createPin(
+    req: Request<unknown, unknown, CreatePinRequest>,
+    res: Response<PinResponse>,
+    next: NextFunction
+  ) {
+    try {
+      const userId = req.user!._id;
+      const pin = await pinModel.create(userId, req.body);
+      res.status(201).json({ message: 'Pin created successfully', data: { pin } });
+    } catch (error) {
+      logger.error('Failed to create pin:', error as Error);
+      if (error instanceof Error) {
+        return res.status(400).json({ message: error.message || 'Failed to create pin' });
+      }
+      next(error);
+    }
+  }
+
+  async getPin(
+    req: Request<{ id: string }>,
+    res: Response<PinResponse>,
+    next: NextFunction
+  ) {
+    try {
+      const pinId = new mongoose.Types.ObjectId(req.params.id);
+      const pin = await pinModel.findById(pinId);
+      if (!pin) return res.status(404).json({ message: 'Pin not found' });
+      res.status(200).json({ message: 'Pin fetched successfully', data: { pin } });
+    } catch (error) {
+      logger.error('Failed to get pin:', error as Error);
+      if (error instanceof Error) {
+        return res.status(500).json({ message: error.message || 'Failed to get pin' });
+      }
+      next(error);
+    }
+  }
+
+  async updatePin(
+    req: Request<{ id: string }, unknown, UpdatePinRequest>,
+    res: Response<PinResponse>,
+    next: NextFunction
+  ) {
+    try {
+      const pinId = new mongoose.Types.ObjectId(req.params.id);
+      const userId = req.user!._id;
+      const pin = await pinModel.update(pinId, userId, req.body);
+      if (!pin) return res.status(404).json({ message: 'Pin not found or unauthorized' });
+      res.status(200).json({ message: 'Pin updated successfully', data: { pin } });
+    } catch (error) {
+      logger.error('Failed to update pin:', error as Error);
+      if (error instanceof Error) {
+        return res.status(500).json({ message: error.message || 'Failed to update pin' });
+      }
+      next(error);
+    }
+  }
+
+  async deletePin(req: Request<{ id: string }>, res: Response, next: NextFunction) {
+    try {
+      const pinId = new mongoose.Types.ObjectId(req.params.id);
+      const userId = req.user!._id;
+      const deleted = await pinModel.delete(pinId, userId);
+      if (!deleted) return res.status(404).json({ message: 'Pin not found or unauthorized' });
+      res.status(200).json({ message: 'Pin deleted successfully' });
+    } catch (error) {
+      logger.error('Failed to delete pin:', error as Error);
+      if (error instanceof Error) {
+        return res.status(500).json({ message: error.message || 'Failed to delete pin' });
+      }
+      next(error);
+    }
+  }
+
+  async searchPins(
+    req: Request<unknown, unknown, unknown, SearchPinsRequest>,
+    res: Response<PinsListResponse>,
+    next: NextFunction
+  ) {
+    try {
+      const { pins, total } = await pinModel.search({
+        category: req.query.category,
+        latitude: req.query.latitude,
+        longitude: req.query.longitude,
+        radius: req.query.radius,
+        search: req.query.search,
+        page: req.query.page,
+        limit: req.query.limit,
+      });
+      res.status(200).json({ message: 'Pins fetched successfully', data: { pins, total, page: req.query.page || 1, limit: req.query.limit || 20 } });
+    } catch (error) {
+      logger.error('Failed to search pins:', error as Error);
+      if (error instanceof Error) {
+        return res.status(500).json({ message: error.message || 'Failed to search pins' });
+      }
+      next(error);
+    }
+  }
+
+  async ratePin(
+    req: Request<{ id: string }, unknown, RatePinRequest>,
+    res: Response,
+    next: NextFunction
+  ) {
+    try {
+      const pinId = new mongoose.Types.ObjectId(req.params.id);
+      const userId = req.user!._id;
+      const { voteType } = req.body;
+      await pinVoteModel.vote(userId, pinId, voteType);
+      res.status(200).json({ message: `Pin ${voteType}d successfully` });
+    } catch (error) {
+      logger.error('Failed to rate pin:', error as Error);
+      if (error instanceof Error) {
+        return res.status(500).json({ message: error.message || 'Failed to rate pin' });
+      }
+      next(error);
+    }
+  }
+
+  async reportPin(
+    req: Request<{ id: string }, unknown, ReportPinRequest>,
+    res: Response,
+    next: NextFunction
+  ) {
+    try {
+      const pinId = new mongoose.Types.ObjectId(req.params.id);
+      const userId = req.user!._id;
+      const { reason } = req.body;
+      await pinModel.reportPin(pinId, userId, reason);
+      res.status(200).json({ message: 'Pin reported successfully' });
+    } catch (error) {
+      logger.error('Failed to report pin:', error as Error);
+      if (error instanceof Error) {
+        return res.status(500).json({ message: error.message || 'Failed to report pin' });
+      }
+      next(error);
+    }
+  }
+}
+
+export const pinsController = new PinsController();
+
+

--- a/backend/src/models/pin.model.ts
+++ b/backend/src/models/pin.model.ts
@@ -1,0 +1,187 @@
+import mongoose, { Schema } from 'mongoose';
+import { z } from 'zod';
+import {
+  IPin,
+  PinCategory,
+  PinStatus,
+  CreatePinRequest,
+  UpdatePinRequest,
+  createPinSchema,
+  updatePinSchema,
+} from '../types/pins.types';
+import logger from '../utils/logger.util';
+
+const pinSchema = new Schema<IPin>(
+  {
+    name: { type: String, required: true, trim: true, maxlength: 100, index: 'text' },
+    category: { type: String, enum: Object.values(PinCategory), required: true, index: true },
+    description: { type: String, required: true, trim: true, maxlength: 500 },
+    location: {
+      latitude: { type: Number, required: true, min: -90, max: 90 },
+      longitude: { type: Number, required: true, min: -180, max: 180 },
+      address: { type: String, trim: true },
+    },
+    createdBy: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    metadata: {
+      capacity: Number,
+      openingHours: String,
+      amenities: [String],
+      crowdLevel: { type: String, enum: ['quiet', 'moderate', 'busy'] },
+    },
+    rating: {
+      upvotes: { type: Number, default: 0 },
+      downvotes: { type: Number, default: 0 },
+      voters: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+    },
+    reports: [
+      {
+        reportedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+        reason: { type: String, required: true },
+        timestamp: { type: Date, default: Date.now },
+      },
+    ],
+    status: { type: String, enum: Object.values(PinStatus), default: PinStatus.ACTIVE, index: true },
+    isPreSeeded: { type: Boolean, default: false },
+    expiresAt: { type: Date, index: true },
+    imageUrl: { type: String, trim: true },
+  },
+  { timestamps: true }
+);
+
+pinSchema.index({ 'location.latitude': 1, 'location.longitude': 1 });
+pinSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export class PinModel {
+  private pin: mongoose.Model<IPin>;
+
+  constructor() {
+    this.pin = mongoose.model<IPin>('Pin', pinSchema);
+  }
+
+  async create(userId: mongoose.Types.ObjectId, pinData: CreatePinRequest): Promise<IPin> {
+    try {
+      const validatedData = createPinSchema.parse(pinData);
+      const pin = await this.pin.create({ ...validatedData, createdBy: userId, status: PinStatus.ACTIVE });
+      return pin;
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        logger.error('Validation error:', error.issues);
+        throw new Error('Invalid pin data');
+      }
+      logger.error('Error creating pin:', error);
+      throw new Error('Failed to create pin');
+    }
+  }
+
+  async findById(pinId: mongoose.Types.ObjectId): Promise<IPin | null> {
+    try {
+      return await this.pin.findById(pinId).populate('createdBy', 'name profilePicture');
+    } catch (error) {
+      logger.error('Error finding pin:', error);
+      throw new Error('Failed to find pin');
+    }
+  }
+
+  async update(pinId: mongoose.Types.ObjectId, userId: mongoose.Types.ObjectId, updates: UpdatePinRequest): Promise<IPin | null> {
+    try {
+      const validatedData = updatePinSchema.parse(updates);
+      const pin = await this.pin.findOneAndUpdate({ _id: pinId, createdBy: userId }, { $set: validatedData }, { new: true });
+      return pin;
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        logger.error('Validation error:', error.issues);
+        throw new Error('Invalid update data');
+      }
+      logger.error('Error updating pin:', error);
+      throw new Error('Failed to update pin');
+    }
+  }
+
+  async delete(pinId: mongoose.Types.ObjectId, userId: mongoose.Types.ObjectId): Promise<boolean> {
+    try {
+      const result = await this.pin.deleteOne({ _id: pinId, createdBy: userId });
+      return result.deletedCount > 0;
+    } catch (error) {
+      logger.error('Error deleting pin:', error);
+      throw new Error('Failed to delete pin');
+    }
+  }
+
+  async search(filters: {
+    category?: PinCategory;
+    latitude?: number;
+    longitude?: number;
+    radius?: number;
+    search?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{ pins: IPin[]; total: number }> {
+    try {
+      const query: any = { status: PinStatus.ACTIVE };
+      const page = filters.page || 1;
+      const limit = filters.limit || 20;
+      const skip = (page - 1) * limit;
+
+      if (filters.category) {
+        query.category = filters.category;
+      }
+      if (filters.search) {
+        query.$text = { $search: filters.search };
+      }
+
+      let pins = await this.pin
+        .find(query)
+        .populate('createdBy', 'name profilePicture')
+        .sort({ createdAt: -1 })
+        .limit(limit)
+        .skip(skip);
+
+      if (filters.latitude && filters.longitude && filters.radius) {
+        pins = pins.filter(p => this.calculateDistance(filters.latitude!, filters.longitude!, p.location.latitude, p.location.longitude) <= filters.radius!);
+      }
+
+      const total = await this.pin.countDocuments(query);
+      return { pins, total };
+    } catch (error) {
+      logger.error('Error searching pins:', error);
+      throw new Error('Failed to search pins');
+    }
+  }
+
+  async reportPin(pinId: mongoose.Types.ObjectId, userId: mongoose.Types.ObjectId, reason: string): Promise<IPin | null> {
+    try {
+      const pin = await this.pin.findByIdAndUpdate(
+        pinId,
+        { $push: { reports: { reportedBy: userId, reason, timestamp: new Date() } } },
+        { new: true }
+      );
+
+      if (pin && pin.reports.length >= 5) {
+        pin.status = PinStatus.REPORTED;
+        await pin.save();
+      }
+
+      return pin;
+    } catch (error) {
+      logger.error('Error reporting pin:', error);
+      throw new Error('Failed to report pin');
+    }
+  }
+
+  private calculateDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
+    const R = 6371;
+    const dLat = this.toRad(lat2 - lat1);
+    const dLon = this.toRad(lon2 - lon1);
+    const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) + Math.cos(this.toRad(lat1)) * Math.cos(this.toRad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c;
+  }
+
+  private toRad(deg: number): number {
+    return deg * (Math.PI / 180);
+  }
+}
+
+export const pinModel = new PinModel();
+
+

--- a/backend/src/models/pinVote.model.ts
+++ b/backend/src/models/pinVote.model.ts
@@ -1,0 +1,87 @@
+import mongoose, { Schema } from 'mongoose';
+import { IPinVote } from '../types/pins.types';
+import { pinModel } from './pin.model';
+import logger from '../utils/logger.util';
+
+const pinVoteSchema = new Schema<IPinVote>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    pinId: { type: Schema.Types.ObjectId, ref: 'Pin', required: true },
+    voteType: { type: String, enum: ['upvote', 'downvote'], required: true },
+  },
+  { timestamps: true }
+);
+
+pinVoteSchema.index({ userId: 1, pinId: 1 }, { unique: true });
+
+export class PinVoteModel {
+  private voteCollection: mongoose.Model<IPinVote>;
+
+  constructor() {
+    this.voteCollection = mongoose.model<IPinVote>('PinVote', pinVoteSchema);
+  }
+
+  async vote(
+    userId: mongoose.Types.ObjectId,
+    pinId: mongoose.Types.ObjectId,
+    voteType: 'upvote' | 'downvote'
+  ): Promise<boolean> {
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+      const existingVote = await this.voteCollection.findOne({ userId, pinId });
+
+      let upvoteChange = 0;
+      let downvoteChange = 0;
+
+      if (existingVote) {
+        if (existingVote.voteType !== voteType) {
+          existingVote.voteType = voteType;
+          await existingVote.save({ session });
+          if (voteType === 'upvote') {
+            upvoteChange = 1;
+            downvoteChange = -1;
+          } else {
+            upvoteChange = -1;
+            downvoteChange = 1;
+          }
+        }
+      } else {
+        await this.voteCollection.create([{ userId, pinId, voteType }], { session });
+        if (voteType === 'upvote') {
+          upvoteChange = 1;
+        } else {
+          downvoteChange = 1;
+        }
+      }
+
+      if (upvoteChange !== 0 || downvoteChange !== 0) {
+        // Access the underlying model to update rating
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const pinCollection = (pinModel as any)['pin'] as mongoose.Model<any>;
+        await pinCollection.findByIdAndUpdate(
+          pinId,
+          {
+            $inc: { 'rating.upvotes': upvoteChange, 'rating.downvotes': downvoteChange },
+            $addToSet: { 'rating.voters': userId },
+          },
+          { session }
+        );
+      }
+
+      await session.commitTransaction();
+      return true;
+    } catch (error) {
+      await session.abortTransaction();
+      logger.error('Error voting on pin:', error);
+      throw new Error('Failed to vote on pin');
+    } finally {
+      session.endSession();
+    }
+  }
+}
+
+export const pinVoteModel = new PinVoteModel();
+
+

--- a/backend/src/routes/pins.routes.ts
+++ b/backend/src/routes/pins.routes.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { authenticateToken } from '../middleware/auth.middleware';
+import { validateBody, validateQuery } from '../middleware/validation.middleware';
+import { pinsController } from '../controllers/pins.controller';
+import {
+  createPinSchema,
+  updatePinSchema,
+  ratePinSchema,
+  reportPinSchema,
+  searchPinsSchema,
+} from '../types/pins.types';
+
+const router = Router();
+
+router.get('/search', validateQuery(searchPinsSchema), pinsController.searchPins);
+router.get('/:id', pinsController.getPin);
+
+router.use(authenticateToken);
+
+router.post('/', validateBody(createPinSchema), pinsController.createPin);
+router.put('/:id', validateBody(updatePinSchema), pinsController.updatePin);
+router.delete('/:id', pinsController.deletePin);
+router.post('/:id/rate', validateBody(ratePinSchema), pinsController.ratePin);
+router.post('/:id/report', validateBody(reportPinSchema), pinsController.reportPin);
+
+export default router;
+
+

--- a/backend/src/routes/routes.ts
+++ b/backend/src/routes/routes.ts
@@ -4,6 +4,7 @@ import { authenticateToken } from '../middleware/auth.middleware';
 import authRoutes from '../routes/auth.routes';
 import mediaRoutes from '../routes/media.routes';
 import usersRoutes from '../routes/user.routes';
+import pinsRoutes from '../routes/pins.routes';
 
 const router = Router();
 
@@ -12,5 +13,7 @@ router.use('/auth', authRoutes);
 router.use('/user', authenticateToken, usersRoutes);
 
 router.use('/media', authenticateToken, mediaRoutes);
+
+router.use('/pins', pinsRoutes);
 
 export default router;

--- a/backend/src/types/pins.types.ts
+++ b/backend/src/types/pins.types.ts
@@ -1,0 +1,136 @@
+import mongoose from 'mongoose';
+import { z } from 'zod';
+
+export enum PinCategory {
+  STUDY = 'study',
+  EVENTS = 'events',
+  CHILL = 'chill',
+  SHOPS_SERVICES = 'shops_services',
+}
+
+export enum PinStatus {
+  ACTIVE = 'active',
+  REPORTED = 'reported',
+  HIDDEN = 'hidden',
+}
+
+export interface IPin {
+  _id: mongoose.Types.ObjectId;
+  name: string;
+  category: PinCategory;
+  description: string;
+  location: {
+    latitude: number;
+    longitude: number;
+    address?: string;
+  };
+  createdBy: mongoose.Types.ObjectId;
+  metadata?: {
+    capacity?: number;
+    openingHours?: string;
+    amenities?: string[];
+    crowdLevel?: 'quiet' | 'moderate' | 'busy';
+  };
+  rating: {
+    upvotes: number;
+    downvotes: number;
+    voters: mongoose.Types.ObjectId[];
+  };
+  reports: Array<{
+    reportedBy: mongoose.Types.ObjectId;
+    reason: string;
+    timestamp: Date;
+  }>;
+  status: PinStatus;
+  isPreSeeded: boolean;
+  expiresAt?: Date;
+  imageUrl?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IPinVote {
+  _id: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId;
+  pinId: mongoose.Types.ObjectId;
+  voteType: 'upvote' | 'downvote';
+  createdAt: Date;
+}
+
+export const createPinSchema = z.object({
+  name: z.string().min(1).max(100),
+  category: z.nativeEnum(PinCategory),
+  description: z.string().min(10).max(500),
+  location: z.object({
+    latitude: z.number().min(-90).max(90),
+    longitude: z.number().min(-180).max(180),
+    address: z.string().optional(),
+  }),
+  metadata: z
+    .object({
+      capacity: z.number().min(0).optional(),
+      openingHours: z.string().optional(),
+      amenities: z.array(z.string()).optional(),
+      crowdLevel: z.enum(['quiet', 'moderate', 'busy']).optional(),
+    })
+    .optional(),
+  expiresAt: z.preprocess((val: unknown) => (val ? new Date(String(val)) : undefined), z.date().optional()),
+  imageUrl: z.string().url().optional(),
+});
+
+export const updatePinSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  description: z.string().min(10).max(500).optional(),
+  metadata: z
+    .object({
+      capacity: z.number().min(0).optional(),
+      openingHours: z.string().optional(),
+      amenities: z.array(z.string()).optional(),
+      crowdLevel: z.enum(['quiet', 'moderate', 'busy']).optional(),
+    })
+    .optional(),
+  imageUrl: z.string().url().optional(),
+});
+
+export const ratePinSchema = z.object({
+  voteType: z.enum(['upvote', 'downvote']),
+});
+
+export const reportPinSchema = z.object({
+  reason: z.string().min(10).max(500),
+});
+
+export const searchPinsSchema = z.object({
+  category: z.nativeEnum(PinCategory).optional(),
+  latitude: z.coerce.number().min(-90).max(90).optional(),
+  longitude: z.coerce.number().min(-180).max(180).optional(),
+  radius: z.coerce.number().min(0).max(50).optional(),
+  search: z.string().optional(),
+  page: z.coerce.number().min(1).optional(),
+  limit: z.coerce.number().min(1).max(100).optional(),
+});
+
+export type CreatePinRequest = z.infer<typeof createPinSchema>;
+export type UpdatePinRequest = z.infer<typeof updatePinSchema>;
+export type RatePinRequest = z.infer<typeof ratePinSchema>;
+export type ReportPinRequest = z.infer<typeof reportPinSchema>;
+export type SearchPinsRequest = z.infer<typeof searchPinsSchema>;
+
+export type PinResponse = {
+  message: string;
+  data?: {
+    pin: IPin;
+  };
+};
+
+export type PinsListResponse = {
+  message: string;
+  data?: {
+    pins: IPin[];
+    total: number;
+    page: number;
+    limit: number;
+  };
+};
+
+


### PR DESCRIPTION
- Overview
  - Implements Manage Pins (P0): CRUD, search, upvote/downvote, report.
  - Adds `pins.types.ts`, `pin.model.ts`, `pinVote.model.ts`, `pins.controller.ts`, `pins.routes.ts`.
  - Adds `validateQuery` and mounts `/api/pins`.
  
- Endpoints
  - Public: GET `/api/pins/search`, GET `/api/pins/:id`
  - Auth: POST `/api/pins`, PUT `/api/pins/:id`, DELETE `/api/pins/:id`, POST `/api/pins/:id/rate`, POST `/api/pins/:id/report`
  
- Notes
  - Text index on `name`, TTL on `expiresAt`; simple distance filter for now.
  - Uses existing JWT auth (`req.user`).
- Follow-ups
  - GeoJSON/2dsphere queries, admin moderation UI, photo uploads (P1).

